### PR TITLE
Add OpenRouter API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,20 @@ export ANTHROPIC_API_KEY="your-key"
 python nanocode.py
 ```
 
-Or use [OpenRouter](https://openrouter.ai):
+### OpenRouter
+
+Use [OpenRouter](https://openrouter.ai) to access any model:
 
 ```bash
 export OPENROUTER_API_KEY="your-key"
+python nanocode.py
+```
+
+To use a different model:
+
+```bash
+export OPENROUTER_API_KEY="your-key"
+export MODEL="openai/gpt-4o"
 python nanocode.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ export ANTHROPIC_API_KEY="your-key"
 python nanocode.py
 ```
 
+Or use [OpenRouter](https://openrouter.ai):
+
+```bash
+export OPENROUTER_API_KEY="your-key"
+python nanocode.py
+```
+
 ## Commands
 
 - `/c` - Clear conversation

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use a different model:
 
 ```bash
 export OPENROUTER_API_KEY="your-key"
-export MODEL="openai/gpt-4o"
+export MODEL="openai/gpt-5.2"
 python nanocode.py
 ```
 

--- a/nanocode.py
+++ b/nanocode.py
@@ -3,9 +3,9 @@
 
 import glob as globlib, json, os, re, subprocess, urllib.request
 
-_OR = os.environ.get("OPENROUTER_API_KEY")
-API_URL = "https://openrouter.ai/api/v1/messages" if _OR else "https://api.anthropic.com/v1/messages"
-MODEL = "anthropic/claude-opus-4.5" if _OR else "claude-opus-4-5"
+OPENROUTER_KEY = os.environ.get("OPENROUTER_API_KEY")
+API_URL = "https://openrouter.ai/api/v1/messages" if OPENROUTER_KEY else "https://api.anthropic.com/v1/messages"
+MODEL = os.environ.get("MODEL", "anthropic/claude-opus-4.5" if OPENROUTER_KEY else "claude-opus-4-5")
 
 # ANSI colors
 RESET, BOLD, DIM = "\033[0m", "\033[1m", "\033[2m"
@@ -167,7 +167,7 @@ def call_api(messages, system_prompt):
         headers={
             "Content-Type": "application/json",
             "anthropic-version": "2023-06-01",
-            **({"Authorization": f"Bearer {_OR}"} if _OR else {"x-api-key": os.environ.get("ANTHROPIC_API_KEY", "")}),
+            **({"Authorization": f"Bearer {OPENROUTER_KEY}"} if OPENROUTER_KEY else {"x-api-key": os.environ.get("ANTHROPIC_API_KEY", "")}),
         },
     )
     response = urllib.request.urlopen(request)
@@ -183,7 +183,7 @@ def render_markdown(text):
 
 
 def main():
-    print(f"{BOLD}nanocode{RESET} | {DIM}{MODEL} ({'OpenRouter' if _OR else 'Anthropic'}) | {os.getcwd()}{RESET}\n")
+    print(f"{BOLD}nanocode{RESET} | {DIM}{MODEL} ({'OpenRouter' if OPENROUTER_KEY else 'Anthropic'}) | {os.getcwd()}{RESET}\n")
     messages = []
     system_prompt = f"Concise coding assistant. cwd: {os.getcwd()}"
 

--- a/nanocode.py
+++ b/nanocode.py
@@ -3,8 +3,11 @@
 
 import glob as globlib, json, os, re, subprocess, urllib.request
 
-API_URL = "https://api.anthropic.com/v1/messages"
-MODEL = "claude-opus-4-5"
+OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
+USE_OPENROUTER = bool(OPENROUTER_API_KEY)
+
+API_URL = "https://openrouter.ai/api/v1/messages" if USE_OPENROUTER else "https://api.anthropic.com/v1/messages"
+MODEL = "anthropic/claude-opus-4.5" if USE_OPENROUTER else "claude-opus-4-5"
 
 # ANSI colors
 RESET, BOLD, DIM = "\033[0m", "\033[1m", "\033[2m"
@@ -152,6 +155,15 @@ def make_schema():
 
 
 def call_api(messages, system_prompt):
+    headers = {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+    }
+    if USE_OPENROUTER:
+        headers["Authorization"] = f"Bearer {OPENROUTER_API_KEY}"
+    else:
+        headers["x-api-key"] = os.environ.get("ANTHROPIC_API_KEY", "")
+
     request = urllib.request.Request(
         API_URL,
         data=json.dumps(
@@ -163,11 +175,7 @@ def call_api(messages, system_prompt):
                 "tools": make_schema(),
             }
         ).encode(),
-        headers={
-            "Content-Type": "application/json",
-            "x-api-key": os.environ.get("ANTHROPIC_API_KEY", ""),
-            "anthropic-version": "2023-06-01",
-        },
+        headers=headers,
     )
     response = urllib.request.urlopen(request)
     return json.loads(response.read())
@@ -182,7 +190,8 @@ def render_markdown(text):
 
 
 def main():
-    print(f"{BOLD}nanocode{RESET} | {DIM}{MODEL} | {os.getcwd()}{RESET}\n")
+    provider = "OpenRouter" if USE_OPENROUTER else "Anthropic"
+    print(f"{BOLD}nanocode{RESET} | {DIM}{MODEL} ({provider}) | {os.getcwd()}{RESET}\n")
     messages = []
     system_prompt = f"Concise coding assistant. cwd: {os.getcwd()}"
 

--- a/nanocode.py
+++ b/nanocode.py
@@ -3,11 +3,9 @@
 
 import glob as globlib, json, os, re, subprocess, urllib.request
 
-OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
-USE_OPENROUTER = bool(OPENROUTER_API_KEY)
-
-API_URL = "https://openrouter.ai/api/v1/messages" if USE_OPENROUTER else "https://api.anthropic.com/v1/messages"
-MODEL = "anthropic/claude-opus-4.5" if USE_OPENROUTER else "claude-opus-4-5"
+_OR = os.environ.get("OPENROUTER_API_KEY")
+API_URL = "https://openrouter.ai/api/v1/messages" if _OR else "https://api.anthropic.com/v1/messages"
+MODEL = "anthropic/claude-opus-4.5" if _OR else "claude-opus-4-5"
 
 # ANSI colors
 RESET, BOLD, DIM = "\033[0m", "\033[1m", "\033[2m"
@@ -155,15 +153,6 @@ def make_schema():
 
 
 def call_api(messages, system_prompt):
-    headers = {
-        "Content-Type": "application/json",
-        "anthropic-version": "2023-06-01",
-    }
-    if USE_OPENROUTER:
-        headers["Authorization"] = f"Bearer {OPENROUTER_API_KEY}"
-    else:
-        headers["x-api-key"] = os.environ.get("ANTHROPIC_API_KEY", "")
-
     request = urllib.request.Request(
         API_URL,
         data=json.dumps(
@@ -175,7 +164,11 @@ def call_api(messages, system_prompt):
                 "tools": make_schema(),
             }
         ).encode(),
-        headers=headers,
+        headers={
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+            **({"Authorization": f"Bearer {_OR}"} if _OR else {"x-api-key": os.environ.get("ANTHROPIC_API_KEY", "")}),
+        },
     )
     response = urllib.request.urlopen(request)
     return json.loads(response.read())
@@ -190,8 +183,7 @@ def render_markdown(text):
 
 
 def main():
-    provider = "OpenRouter" if USE_OPENROUTER else "Anthropic"
-    print(f"{BOLD}nanocode{RESET} | {DIM}{MODEL} ({provider}) | {os.getcwd()}{RESET}\n")
+    print(f"{BOLD}nanocode{RESET} | {DIM}{MODEL} ({'OpenRouter' if _OR else 'Anthropic'}) | {os.getcwd()}{RESET}\n")
     messages = []
     system_prompt = f"Concise coding assistant. cwd: {os.getcwd()}"
 


### PR DESCRIPTION
This PR adds support for using OpenRouter as an alternative API provider.

## Changes
- Automatically detects `OPENROUTER_API_KEY` environment variable
- When set, routes requests through OpenRouter API instead of Anthropic
- Uses `anthropic/claude-opus-4.5` model identifier for OpenRouter
- Falls back to direct Anthropic API when no OpenRouter key is present
- Displays active provider in the startup message

## Usage
```bash
# Use OpenRouter
export OPENROUTER_API_KEY="your-key"
python nanocode.py

# Use Anthropic (default)
export ANTHROPIC_API_KEY="your-key"
python nanocode.py
```

The implementation is minimal (~4 lines of net changes) to keep the codebase clean.