### PR TITLE
fix: stream bash command output in real-time

### DIFF
--- a/nanocode.py
+++ b/nanocode.py
@@ -75,10 +75,25 @@ def grep(args):
 
 
 def bash(args):
-    result = subprocess.run(
-        args["cmd"], shell=True, capture_output=True, text=True, timeout=30
+    proc = subprocess.Popen(
+        args["cmd"], shell=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True
     )
-    return (result.stdout + result.stderr).strip() or "(empty)"
+    output_lines = []
+    try:
+        while True:
+            line = proc.stdout.readline()
+            if not line and proc.poll() is not None:
+                break
+            if line:
+                print(f"  {DIM}│ {line.rstrip()}{RESET}", flush=True)
+                output_lines.append(line)
+        proc.wait(timeout=30)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        output_lines.append("\n(timed out after 30s)")
+    return "".join(output_lines).strip() or "(empty)"
 
 
 # --- Tool definitions: (description, schema, function) ---


### PR DESCRIPTION
Fixes #1

## Problem
Commands that wait for input (like `tailscale up`) would show no output until they completed or timed out. Users couldn't see sign-in URLs or other intermediate output.

## Solution
Replace `subprocess.run` (which buffers all output) with `subprocess.Popen` + `readline()` to stream output line-by-line as it's produced.

## Changes
- Use `subprocess.Popen` instead of `subprocess.run`
- Read and display output line-by-line with `readline()`
- Merge stderr into stdout so all output is shown in order
- Add `flush=True` to ensure immediate display

## Testing
Verified that output appears immediately when produced, not buffered until command completion.