### PR TITLE
feat: interactive diff confirmation for writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nanocode
 
-Minimal Claude Code alternative. Single Python file, zero dependencies, ~250 lines.
+Minimal Claude Code alternative. Single Python file, zero dependencies, ~340 lines.
 
 Built using Claude Code, then used to build itself.
 
@@ -12,6 +12,7 @@ Built using Claude Code, then used to build itself.
 - Tools: `read`, `write`, `edit`, `glob`, `grep`, `bash`
 - Conversation history
 - Colored terminal output
+- Diff confirmation: file changes show colored diffs with line numbers; accept/decline via arrow keys, optional decline reason sent to model
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nanocode
 
-Minimal Claude Code alternative. Single Python file, zero dependencies, ~340 lines.
+Minimal Claude Code alternative. Single Python file, zero dependencies, ~337 lines.
 
 Built using Claude Code, then used to build itself.
 
@@ -12,7 +12,7 @@ Built using Claude Code, then used to build itself.
 - Tools: `read`, `write`, `edit`, `glob`, `grep`, `bash`
 - Conversation history
 - Colored terminal output
-- Diff confirmation: file changes show colored diffs with line numbers; accept/decline via arrow keys, optional decline reason sent to model
+- Diff confirmation: file changes show colored diffs with line numbers; accept/decline, optional decline reason sent to model
 
 ## Usage
 


### PR DESCRIPTION
Add interactive diff confirmation for file changes (write/edit tools). Users see a colored diff with line numbers and
can accept or decline. Declined changes include optional feedback sent to the model.

## UI Example

<img width="887" height="1086" alt="image" src="https://github.com/user-attachments/assets/a794920e-a3d9-418c-bb8c-5c98c685430f" />

## Summary

    - Simple selection menu: [Enter] = accept, [d] = decline
    - Colored diff: red (removed), green (added), dim (context)
    - Optional decline reason sent back to model as feedback
    - No new dependencies > only stdlib: difflib, termios, tty and sys