### PR TITLE
feat: add request error print

### DIFF
--- a/nanocode.py
+++ b/nanocode.py
@@ -185,8 +185,12 @@ def call_api(messages, system_prompt):
             **({"Authorization": f"Bearer {OPENROUTER_KEY}"} if OPENROUTER_KEY else {"x-api-key": os.environ.get("ANTHROPIC_API_KEY", "")}),
         },
     )
-    response = urllib.request.urlopen(request)
-    return json.loads(response.read())
+    try:
+        response = urllib.request.urlopen(request)
+        return json.loads(response.read())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        raise Exception(f"API Error ({e.code}) {error_body}")
 
 
 def separator():


### PR DESCRIPTION
Added an API call error display feature, with the style as shown in the image.

<img width="1383" height="203" alt="image" src="https://github.com/user-attachments/assets/d6974671-22ae-4750-aed4-738c0917f6a9" />
